### PR TITLE
- Generate cast methods for Content

### DIFF
--- a/smb-cli/src/copy.rs
+++ b/smb-cli/src/copy.rs
@@ -64,7 +64,7 @@ async fn do_copy_task(
             }
         };
         // 2. Read chunk from remote
-        from.read_block(&mut chunk[..size], (idx * CHUNK_SIZE) as u64)
+        from.read_block(&mut chunk[..size], (idx * CHUNK_SIZE) as u64, false)
             .await?;
         // 3. Write chunk to destination
         {

--- a/smb/src/compression.rs
+++ b/smb/src/compression.rs
@@ -429,10 +429,7 @@ mod tests {
             }
         );
         // unwrap & validate read response.
-        let read_response = match plain_unwrapped.content {
-            Content::ReadResponse(r) => r,
-            _ => panic!("Expected read response"),
-        };
+        let read_response = plain_unwrapped.content.to_readresponse().unwrap();
         assert_eq!(
             read_response,
             ReadResponse {

--- a/smb/src/connection.rs
+++ b/smb/src/connection.rs
@@ -113,13 +113,7 @@ impl Connection {
                 }
             };
 
-            let smb2_negotiate_response = match message.content {
-                Content::NegotiateResponse(response) => Some(response),
-                _ => None,
-            }
-            .ok_or(Error::InvalidMessage(
-                "Expected Negotiate response.".to_string(),
-            ))?;
+            let smb2_negotiate_response = message.content.to_negotiateresponse()?;
 
             // 3. Make sure dialect is smb2*, message ID is 0.
             if smb2_negotiate_response.dialect_revision != NegotiateDialect::Smb02Wildcard {
@@ -185,13 +179,7 @@ impl Connection {
             )))
             .await?;
 
-        let smb2_negotiate_response = match response.message.content {
-            Content::NegotiateResponse(response) => Some(response),
-            _ => None,
-        }
-        .ok_or(Error::InvalidMessage(
-            "Expected Negotiate response.".to_string(),
-        ))?;
+        let smb2_negotiate_response = response.message.content.to_negotiateresponse()?;
 
         // well, only 3.1 is supported for starters.
         let dialect_rev = smb2_negotiate_response.dialect_revision.try_into()?;
@@ -286,7 +274,7 @@ impl Connection {
         Session::setup(
             user_name,
             password,
-            self.handler.clone(),
+            &self.handler,
             self.handler.conn_info.get().unwrap(),
         )
         .await

--- a/smb/src/error.rs
+++ b/smb/src/error.rs
@@ -38,6 +38,11 @@ pub enum Error {
     ReceivedErrorMessage(Status, ErrorResponse),
     #[error("Unexpected command: {0}")]
     UnexpectedCommand(Command),
+    #[error("Unexpected content: {0} - expected {1}", actual, expected)]
+    UnexpectedContent {
+        actual: &'static str,
+        expected: &'static str,
+    },
     #[error("Missing permissions to perform {0}")]
     MissingPermissions(String),
     #[error("Sspi error: {0}")]
@@ -75,6 +80,8 @@ pub enum Error {
     InvalidAddress(String),
     #[error("Invalid configuration: {0}")]
     InvalidConfiguration(String),
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
 }
 
 impl<T> From<PoisonError<T>> for Error {

--- a/smb/src/packets/smb2/create.rs
+++ b/smb/src/packets/smb2/create.rs
@@ -94,7 +94,7 @@ pub enum ImpersonationLevel {
 }
 
 #[binrw::binrw]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[brw(repr(u32))]
 pub enum CreateDisposition {
     Superseded = 0x0,
@@ -768,10 +768,7 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00,
         ];
-        let m = match decode_content(&data).content {
-            Content::CreateResponse(m) => m,
-            _ => panic!("Expected SMBCreateResponse"),
-        };
+        let m = decode_content(&data).content.to_createresponse().unwrap();
         assert_eq!(
             m,
             CreateResponse {

--- a/smb/src/packets/smb2/file.rs
+++ b/smb/src/packets/smb2/file.rs
@@ -267,10 +267,7 @@ mod tests {
         ];
         let parsed = PlainMessage::read(&mut Cursor::new(data)).unwrap();
         // extract read response:
-        let resp = match parsed.content {
-            Content::ReadResponse(resp) => resp,
-            _ => panic!("Unexpected message type"),
-        };
+        let resp = parsed.content.to_readresponse().unwrap();
         assert_eq!(
             resp,
             ReadResponse {

--- a/smb/src/packets/smb2/info/query.rs
+++ b/smb/src/packets/smb2/info/query.rs
@@ -304,10 +304,7 @@ mod tests {
             0x6b, 0xdb, 0x1, 0x4, 0x8f, 0xa1, 0xd, 0x51, 0x6b, 0xdb, 0x1, 0x20, 0x0, 0x0, 0x0, 0x0,
             0x0, 0x0, 0x0,
         ]);
-        let parsed = match parsed.content {
-            Content::QueryInfoResponse(x) => x,
-            _ => panic!("Expected QueryInfoResponse, got {:?}", parsed),
-        };
+        let parsed = parsed.content.to_queryinforesponse().unwrap();
         assert_eq!(
             parsed,
             QueryInfoResponse {

--- a/smb/src/packets/smb2/ioctl/msg.rs
+++ b/smb/src/packets/smb2/ioctl/msg.rs
@@ -300,10 +300,7 @@ mod tests {
             0x0, 0x0, 0x0, 0x0, 0x0,
         ];
         let message = decode_content(&data);
-        let message = match message.content {
-            Content::IoctlResponse(message) => message,
-            _ => panic!("Expected IoctlResponse"),
-        };
+        let message = message.content.to_ioctlresponse().unwrap();
         assert_eq!(
             message,
             IoctlResponse {

--- a/smb/src/packets/smb2/negotiate.rs
+++ b/smb/src/packets/smb2/negotiate.rs
@@ -573,10 +573,10 @@ mod tests {
             0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x2, 0x0, 0x4, 0x0,
         ];
 
-        let response = match decode_content(&data).content {
-            Content::NegotiateResponse(response) => response,
-            _ => panic!("Expected NegotiateResponse"),
-        };
+        let response = decode_content(&data)
+            .content
+            .to_negotiateresponse()
+            .unwrap();
 
         assert_eq!(
             response,

--- a/smb/src/packets/smb2/notify.rs
+++ b/smb/src/packets/smb2/notify.rs
@@ -125,10 +125,7 @@ mod tests {
         ];
 
         let parsed = decode_content(&data);
-        let notify_response = match parsed.content {
-            Content::ChangeNotifyResponse(response) => response,
-            _ => panic!("Unexpected response type"),
-        };
+        let notify_response = parsed.content.to_changenotifyresponse().unwrap();
 
         assert_eq!(
             notify_response,

--- a/smb/src/packets/smb2/session_setup.rs
+++ b/smb/src/packets/smb2/session_setup.rs
@@ -170,10 +170,10 @@ mod tests {
             0xa8, 0x76, 0xd8, 0x78, 0xc5, 0x69, 0xdb, 0x1, 0x0, 0x0, 0x0, 0x0,
         ];
 
-        let response = match decode_content(&data).content {
-            Content::SessionSetupResponse(response) => response,
-            _ => panic!("Unexpected message type"),
-        };
+        let response = decode_content(&data)
+            .content
+            .to_sessionsetupresponse()
+            .unwrap();
 
         assert_eq!(
             response,

--- a/smb/src/packets/smb2/tree_connect.rs
+++ b/smb/src/packets/smb2/tree_connect.rs
@@ -196,10 +196,10 @@ type PrivilegeData = BlobData<LuidAttrData>;
 type PrivilegeArrayData = ArrayData<PrivilegeData>;
 
 impl TreeConnectRequest {
-    pub fn new(name: &String) -> TreeConnectRequest {
+    pub fn new(name: &str) -> TreeConnectRequest {
         TreeConnectRequest {
             flags: TreeConnectRequestFlags::new(),
-            buffer: name.clone().into(),
+            buffer: name.into(),
             tree_connect_contexts: vec![],
         }
     }
@@ -211,7 +211,7 @@ pub struct TreeConnectResponse {
     #[bw(calc = 16)]
     #[br(assert(_structure_size == 16))]
     _structure_size: u16,
-    pub share_type: TreeConnectShareType,
+    pub share_type: ShareType,
     #[bw(calc = 0)]
     #[br(assert(_reserved == 0))]
     _reserved: u8,
@@ -278,9 +278,9 @@ pub struct TreeCapabilities {
 }
 
 #[binrw::binrw]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[brw(repr(u8))]
-pub enum TreeConnectShareType {
+pub enum ShareType {
     Disk = 0x1,
     Pipe = 0x2,
     Print = 0x3,
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     pub fn test_tree_connect_req_write() {
         let result = encode_content(Content::TreeConnectRequest(TreeConnectRequest::new(
-            &r"\\127.0.0.1\MyShare".into(),
+            &r"\\127.0.0.1\MyShare",
         )));
         assert_eq!(
             result,
@@ -341,7 +341,7 @@ mod tests {
         assert_eq!(
             content_parsed,
             TreeConnectResponse {
-                share_type: TreeConnectShareType::Disk,
+                share_type: ShareType::Disk,
                 share_flags: TreeShareFlags::new().with_access_based_directory_enum(true),
                 capabilities: TreeCapabilities::new(),
                 maximal_access: 0x001f01ff,

--- a/smb/src/resource/directory.rs
+++ b/smb/src/resource/directory.rs
@@ -40,10 +40,10 @@ impl Directory {
             }))
             .await?;
 
-        let content = match response.message.content {
-            Content::QueryDirectoryResponse(response) => response,
-            _ => panic!("Unexpected response"),
-        };
-        Ok(content.read_output()?)
+        Ok(response
+            .message
+            .content
+            .to_querydirectoryresponse()?
+            .read_output()?)
     }
 }

--- a/smb/tests/integration_tests.rs
+++ b/smb/tests/integration_tests.rs
@@ -132,7 +132,7 @@ async fn test_smb_integration_basic(
         .await?;
 
         let mut buf = [0u8; TEST_DATA.len() + 2];
-        let read_length = file.read_block(&mut buf, 0).await?;
+        let read_length = file.read_block(&mut buf, 0, false).await?;
         assert_eq!(read_length, TEST_DATA.len());
         assert_eq!(&buf[..read_length], TEST_DATA);
 


### PR DESCRIPTION
- Support unbuffered read - #35
- validate share type on create
- making handlered objects (Resource/Session/Tree) now only build instances after connected properly