### PR TITLE
#46 (bugfix): Add Send+Sync to GssAuthTokenHandler 

### DIFF
--- a/smb/src/session/authenticator.rs
+++ b/smb/src/session/authenticator.rs
@@ -173,7 +173,7 @@ impl GssAuthenticator {
     }
 }
 
-pub trait GssAuthTokenHandler {
+pub trait GssAuthTokenHandler: Send + Sync {
     fn next(&mut self, ntlm_token: Option<Vec<u8>>) -> crate::Result<Vec<u8>>;
     fn gss_getmic(&mut self, buffer: &mut [u8]) -> crate::Result<Vec<u8>>;
     fn gss_validatemic(&mut self, buffer: &mut [u8], signature: &mut [u8]) -> crate::Result<()>;


### PR DESCRIPTION
to allow share using objects between tasks
closes #46 by @phughesion-h3
