### PR TITLE
Add [br] tags to improve nightly build

### DIFF
--- a/smb/Cargo.toml
+++ b/smb/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.8.5"
 log = "0.4.22"
 time = { version = "0.3.37", features = ["macros"] }
 thiserror = "2.0"
-paste = "1.0.15"
+paste = "1.0"
 url = "2.5.0"
 
 # APIs

--- a/smb/Cargo.toml
+++ b/smb/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.8.5"
 log = "0.4.22"
 time = { version = "0.3.37", features = ["macros"] }
 thiserror = "2.0"
-paste = "1.0"
+paste = "1.0.15"
 url = "2.5.0"
 
 # APIs

--- a/smb/src/packets/dfsc.rs
+++ b/smb/src/packets/dfsc.rs
@@ -44,6 +44,7 @@ pub struct ReqGetDfsReferralEx {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct DfsRequestFlags {
     /// SiteName present: The SiteName bit MUST be set to 1 if the packet contains the site name of the client.
     pub site_name: bool,
@@ -90,6 +91,7 @@ pub struct RespGetDfsReferral {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct ReferralHeaderFlags {
     /// Whether all of the targets in the referral entries returned are DFS root targets capable of handling DFS referral requests.
     pub referral_servers: bool,
@@ -235,6 +237,7 @@ impl ReferralEntryValueV3 {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct ReferralEntryFlags {
     #[skip]
     __: bool,
@@ -344,6 +347,7 @@ pub struct ReferralEntryValueV4 {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 struct ReferralEntryFlagsV4 {
     #[skip]
     __: B2,

--- a/smb/src/packets/fscc.rs
+++ b/smb/src/packets/fscc.rs
@@ -24,6 +24,7 @@ pub use set_file_info::*;
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct FileAttributes {
     pub readonly: bool,
     pub hidden: bool,

--- a/smb/src/packets/fscc/common_info.rs
+++ b/smb/src/packets/fscc/common_info.rs
@@ -41,6 +41,7 @@ pub type FileFullEaInformationCommon = ChainedItem<FileFullEaInformationInner>;
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct FileModeInformation {
     #[skip]
     __: bool,

--- a/smb/src/packets/fscc/filesystem_info.rs
+++ b/smb/src/packets/fscc/filesystem_info.rs
@@ -38,6 +38,7 @@ pub struct FileFsAttributeInformation {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct FileSystemAttributes {
     pub case_sensitive_search: bool,
     pub case_preserved_names: bool,
@@ -97,6 +98,7 @@ pub enum FsDeviceType {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct FsDeviceCharacteristics {
     pub removable_media: bool,
     pub read_only: bool,
@@ -127,6 +129,7 @@ pub struct FsDeviceCharacteristics {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct FileSystemControlFlags {
     pub quota_track: bool,
     pub quota_enforce: bool,
@@ -177,6 +180,7 @@ pub struct FileFsSectorSizeInformation {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct SectorSizeInfoFlags {
     pub aligned_device: bool,
     pub partition_aligned_on_device: bool,

--- a/smb/src/packets/rpc/interface/srvsvc.rs
+++ b/smb/src/packets/rpc/interface/srvsvc.rs
@@ -124,6 +124,7 @@ pub enum ShareKind {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct ShareType {
     pub kind: ShareKind,
     #[skip]

--- a/smb/src/packets/rpc/ndr64/string.rs
+++ b/smb/src/packets/rpc/ndr64/string.rs
@@ -24,8 +24,7 @@ where
     #[br(assert(*offset == 0))] // TODO: Support non-zero offsets!
     offset: NdrAlign<u64>,
     #[bw(calc = (data.len() as u64).into())]
-    #[br(assert((SIZE == 0 || *actual_count < SIZE as u64) ||
-                (SIZE != 0 && *actual_count < *(alloc_length.unwrap()) as u64)))]
+    #[br(assert((SIZE == 0 || *actual_count < SIZE as u64) || *actual_count < *(alloc_length.unwrap()) as u64))]
     actual_count: NdrAlign<u64>,
     #[br(count = *actual_count, args { inner: args })]
     #[bw(args_raw(args))]

--- a/smb/src/packets/rpc/pdu.rs
+++ b/smb/src/packets/rpc/pdu.rs
@@ -173,6 +173,7 @@ pub struct DceRpcVersion {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct DceRpcCoPktFlags {
     pub first_frag: bool,
     pub last_frag: bool,

--- a/smb/src/packets/security/ace.rs
+++ b/smb/src/packets/security/ace.rs
@@ -24,6 +24,7 @@ macro_rules! access_mask {
     #[bitfield]
     #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
     #[bw(map = |&x| Self::into_bytes(x))]
+    #[br(map = Self::from_bytes)]
         $vis struct $name {
             // User fields
             $(
@@ -171,6 +172,7 @@ pub struct AccessObjectAce {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct ObjectAceFlags {
     pub object_type_present: bool,
     pub inherited_object_type_present: bool,
@@ -247,6 +249,7 @@ pub enum ClaimSecurityAttributeType {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct FciClaimSecurityAttributes {
     pub non_inheritable: bool,
     pub value_case_sensitive: bool,
@@ -293,6 +296,7 @@ pub enum AceType {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct AceFlags {
     pub object_inherit: bool,
     pub container_inherit: bool,

--- a/smb/src/packets/security/security_descriptor.rs
+++ b/smb/src/packets/security/security_descriptor.rs
@@ -42,6 +42,7 @@ pub struct SecurityDescriptor {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct SecurityDescriptorControl {
     pub owner_defaulted: bool,
     pub group_defaulted: bool,

--- a/smb/src/packets/smb2/create.rs
+++ b/smb/src/packets/smb2/create.rs
@@ -114,6 +114,7 @@ pub enum CreateDisposition {
 #[bitfield]
 #[derive(BinWrite, BinRead, Default, Debug, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct CreateOptions {
     pub directory_file: bool,
     pub write_through: bool,
@@ -154,6 +155,7 @@ pub struct CreateOptions {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct ShareAccessFlags {
     pub read: bool,
     pub write: bool,
@@ -199,6 +201,7 @@ pub struct CreateResponse {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct CreateResponseFlags {
     pub reparsepoint: bool,
     #[skip]
@@ -535,6 +538,7 @@ pub struct DurableHandleRequestV2 {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct DurableHandleV2Flags {
     #[skip]
     __: bool,
@@ -690,6 +694,7 @@ pub struct CloseResponse {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct CloseFlags {
     pub postquery_attrib: bool,
     #[skip]

--- a/smb/src/packets/smb2/file.rs
+++ b/smb/src/packets/smb2/file.rs
@@ -110,6 +110,7 @@ impl ReadResponse {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Default, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct ReadFlags {
     pub read_unbuffered: bool,
     pub read_compressed: bool,
@@ -183,6 +184,7 @@ pub struct WriteResponse {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Default, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct WriteFlags {
     pub write_unbuffered: bool,
     pub write_through: bool,

--- a/smb/src/packets/smb2/header.rs
+++ b/smb/src/packets/smb2/header.rs
@@ -205,6 +205,7 @@ impl Header {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct HeaderFlags {
     pub server_to_redir: bool,
     pub async_command: bool,

--- a/smb/src/packets/smb2/info/common.rs
+++ b/smb/src/packets/smb2/info/common.rs
@@ -16,6 +16,7 @@ pub enum InfoType {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, Default)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct AdditionalInfo {
     pub owner_security_information: bool,
     pub group_security_information: bool,

--- a/smb/src/packets/smb2/info/query.rs
+++ b/smb/src/packets/smb2/info/query.rs
@@ -83,6 +83,7 @@ impl AdditionalInfo {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct QueryInfoFlags {
     pub restart_scan: bool,
     pub return_single_entry: bool,

--- a/smb/src/packets/smb2/ioctl/fsctl.rs
+++ b/smb/src/packets/smb2/ioctl/fsctl.rs
@@ -256,6 +256,7 @@ pub struct NetworkInterfaceInfoContent {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct NetworkInterfaceCapability {
     pub rss: bool,
     pub rdma: bool,

--- a/smb/src/packets/smb2/ioctl/msg.rs
+++ b/smb/src/packets/smb2/ioctl/msg.rs
@@ -102,6 +102,7 @@ ioctl_req_data! {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct IoctlRequestFlags {
     pub is_fsctl: bool,
     #[skip]

--- a/smb/src/packets/smb2/lock.rs
+++ b/smb/src/packets/smb2/lock.rs
@@ -19,6 +19,7 @@ pub struct LockRequest {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct LockSequence {
     pub number: B4,
     pub index: B28,
@@ -38,6 +39,7 @@ pub struct LockElement {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct LockFlag {
     pub shared: bool,
     pub exclusive: bool,

--- a/smb/src/packets/smb2/negotiate.rs
+++ b/smb/src/packets/smb2/negotiate.rs
@@ -41,6 +41,7 @@ pub struct NegotiateRequest {
 #[bitfield]
 #[derive(BinRead, BinWrite, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct NegotiateSecurityMode {
     pub signing_enabled: bool,
     pub signing_required: bool,
@@ -51,6 +52,7 @@ pub struct NegotiateSecurityMode {
 #[bitfield]
 #[derive(BinRead, BinWrite, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct GlobalCapabilities {
     pub dfs: bool,
     pub leasing: bool,
@@ -379,6 +381,7 @@ impl std::fmt::Display for CompressionAlgorithm {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct CompressionCapsFlags {
     pub chained: bool,
     #[skip]
@@ -394,6 +397,7 @@ pub struct NetnameNegotiateContextId {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct TransportCapabilities {
     pub accept_transport_layer_security: bool,
     #[skip]

--- a/smb/src/packets/smb2/notify.rs
+++ b/smb/src/packets/smb2/notify.rs
@@ -25,6 +25,7 @@ pub struct ChangeNotifyRequest {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct NotifyFlags {
     pub watch_tree: bool,
     #[skip]
@@ -34,6 +35,7 @@ pub struct NotifyFlags {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct NotifyFilter {
     pub file_name: bool,
     pub dir_name: bool,

--- a/smb/src/packets/smb2/oplock.rs
+++ b/smb/src/packets/smb2/oplock.rs
@@ -52,6 +52,7 @@ pub enum OplockLevel {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct LeaseState {
     pub read_caching: bool,
     pub handle_caching: bool,

--- a/smb/src/packets/smb2/query_dir.rs
+++ b/smb/src/packets/smb2/query_dir.rs
@@ -38,6 +38,7 @@ pub struct QueryDirectoryRequest {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct QueryDirectoryFlags {
     pub restart_scans: bool,
     pub return_single_entry: bool,

--- a/smb/src/packets/smb2/session_setup.rs
+++ b/smb/src/packets/smb2/session_setup.rs
@@ -26,6 +26,7 @@ pub struct SessionSetupRequest {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct SessionSecurityMode {
     pub signing_enabled: bool,
     pub signing_required: bool,
@@ -36,6 +37,7 @@ pub struct SessionSecurityMode {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct SetupRequestFlags {
     pub binding: bool,
     #[skip]
@@ -45,6 +47,7 @@ pub struct SetupRequestFlags {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct NegotiateCapabilities {
     pub dfs: bool,
     #[skip]
@@ -83,6 +86,7 @@ pub struct SessionSetupResponse {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct SessionFlags {
     pub is_guest: bool,
     pub is_null_session: bool,

--- a/smb/src/packets/smb2/tree_connect.rs
+++ b/smb/src/packets/smb2/tree_connect.rs
@@ -9,6 +9,7 @@ use modular_bitfield::prelude::*;
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct TreeConnectRequestFlags {
     pub cluster_reconnect: bool,
     pub redirect_to_owner: bool,
@@ -161,6 +162,7 @@ type SidArrayData = ArrayData<SidAttrData>;
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct SidAttrSeGroup {
     pub mandatory: bool,
     pub enabled_by_default: bool,
@@ -184,6 +186,7 @@ pub struct LuidAttrData {
 /// [MS-LSAD 2.2.5.4](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lsad/03c834c0-f310-4e0c-832e-b6e7688364d1)
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
+#[br(map = Self::from_bytes)]
 pub struct LsaprLuidAttributes {
     pub default: bool,
     pub enabled: bool,
@@ -233,6 +236,7 @@ pub enum ShareCacheMode {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct ShareFlags {
     pub dfs: bool,
     pub dfs_root: bool,
@@ -263,6 +267,7 @@ pub struct ShareFlags {
 #[bitfield]
 #[derive(BinWrite, BinRead, Debug, Clone, Copy, PartialEq, Eq)]
 #[bw(map = |&x| Self::into_bytes(x))]
+#[br(map = Self::from_bytes)]
 pub struct TreeCapabilities {
     #[skip]
     __: B3,

--- a/smb/src/packets/smb2/tree_connect.rs
+++ b/smb/src/packets/smb2/tree_connect.rs
@@ -82,8 +82,8 @@ macro_rules! make_remoted_identity_connect{
     ) => {
         paste::paste! {
 
-#[binrw::binrw]
-#[derive(Debug)]
+#[binwrite]
+#[derive(Debug, BinRead)]
 pub struct RemotedIdentityTreeConnect {
     // MS-SMB2 2.2.9.2.1: Must be set to 0x1.
     #[bw(calc = PosMarker::new(1))]


### PR DESCRIPTION
This PR is more to start a conversation about fix building on nightly. It fixes most of the errors except this:
```
error: custom attribute panicked
--> smb/src/packets/smb2/tree_connect.rs:85:1
|  
85  |   #[binrw::binrw] 
      |   ^^^^^^^^^^^^^^^
...  
111 | / make_remoted_identity_connect! {
112 | |     user: SidAttrData,
113 | |     user_name: NullWideString,
114 | |     domain: NullWideString,
...   | 
123 | |     device_claims: BlobData<ClaimSecurityAttributeRelativeV1>
124 | | }
 | |_- in this macro invocation
| 
= help: message: byte index 2 is out of bounds of `#`
= note: this error originates in the macro `make_remoted_identity_connect` (in Nightly builds, run with -Z macro-backtrace for more info)
```
I'm not sure how to fix the macro in question. We could certainly fix it by de-macroing it, but that might not be what you want. This PR *should* be okay to merge though as it builds just fine on stable. It reduces nightly compile errors, but it doesn't fix them completely.