### PR TITLE
Proper sharing violation, remove allow_async

### DIFF
--- a/smb/src/packets/smb2/header.rs
+++ b/smb/src/packets/smb2/header.rs
@@ -140,6 +140,7 @@ make_status! {
     ObjectNameInvalid = 0xC0000033: "Object Name Invalid",
     ObjectNameNotFound = 0xC0000034: "Object Name Not Found",
     ObjectNameCollision = 0xC0000035: "Object Name Collision",
+    SharingViloation = 0xC0000043: "Sharing Violation",
     ObjectPathNotFound = 0xC000003A: "Object Path Not Found",
     LogonFailure = 0xC000006D: "Logon Failure",
     BadImpersonationLevel = 0xC00000A5: "Bad Impersonation Level",

--- a/smb/src/resource.rs
+++ b/smb/src/resource.rs
@@ -130,7 +130,9 @@ impl Resource {
         // Make sure to set DFS if required.
         msg.message.header.flags.set_dfs_operation(is_dfs);
 
-        let response = upstream.sendo_recv(msg).await?;
+        let response = upstream
+            .sendo_recvo(msg, ReceiveOptions::new().with_allow_async(true))
+            .await?;
 
         let response = response.message.content.to_create()?;
         log::info!("Created file '{}', ({:?})", name, response.file_id);

--- a/smb/src/resource/file.rs
+++ b/smb/src/resource/file.rs
@@ -155,7 +155,7 @@ impl File {
 
         let response = self
             .handle
-            .send_receive(
+            .send_recvo(
                 WriteRequest {
                     offset: pos,
                     file_id: self.handle.file_id,
@@ -163,6 +163,7 @@ impl File {
                     buffer: buf.to_vec(),
                 }
                 .into(),
+                ReceiveOptions::new().with_allow_async(true),
             )
             .await
             .map_err(|e| std::io::Error::other(e.to_string()))?;
@@ -186,11 +187,12 @@ impl File {
     pub async fn flush(&self) -> std::io::Result<()> {
         let _response = self
             .handle
-            .send_receive(
+            .send_recvo(
                 FlushRequest {
                     file_id: self.handle.file_id,
                 }
                 .into(),
+                ReceiveOptions::new().with_allow_async(true),
             )
             .await
             .map_err(|e| std::io::Error::other(e.to_string()))?;


### PR DESCRIPTION
Previously smb-rs if remote file is open for write by another process, rust client would fail with:
```
[2025-08-08T07:14:44Z ERROR smb_cli] Error: Invalid argument: Async command is not allowed in this context.
Error: InvalidArgument("Async command is not allowed in this context.")
```

And now it fails with proper error:
```
[2025-08-08T07:21:07Z ERROR smb_cli] Error: Server returned an error message with status: Sharing Violation (0xc0000043).
Error: ReceivedErrorMessage(3221225539, ErrorResponse { error_data: [] })
```

Also for `allow_async`. It looks like something that was mistakenly added. As windows returns async-flagged packets (including STATUS_PENDING) even when original create request does not have this flag.