### PR TITLE
#123: Add CLI Security and fix SD write bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,29 +160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,29 +191,6 @@ name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
-
-[[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.4",
- "cexpr",
- "clang-sys",
- "itertools",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.106",
- "which",
-]
 
 [[package]]
 name = "binrw"
@@ -332,8 +286,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -356,15 +308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,17 +327,6 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -446,15 +378,6 @@ dependencies = [
  "cipher",
  "dbl",
  "digest",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -644,12 +567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,16 +656,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "fastbloom"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,12 +703,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -947,12 +848,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,15 +886,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1255,15 +1141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,16 +1193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.3",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,38 +1221,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
-name = "libloading"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
-dependencies = [
- "cfg-if",
- "windows-targets 0.53.3",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -1467,12 +1312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,16 +1350,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1924,16 +1753,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,7 +1781,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.16",
@@ -1983,7 +1802,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2224,12 +2043,6 @@ checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -2244,25 +2057,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.9.4",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "rustls"
 version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2327,7 +2126,6 @@ version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3288,18 +3086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     client.share_connect(&target_path, "username", "password".to_string()).await?;
     
     // And open a file on the server
-    let file_to_open = target_path.with_path("file.txt".to_string());
+    let file_to_open = target_path.with_path("file.txt");
     let file_open_args = FileCreateArgs::make_open_existing(FileAccessMask::new().with_generic_read(true));
     let resource = client.create_file(&file_to_open, &file_open_args).await?;
 

--- a/smb-cli/src/cli.rs
+++ b/smb-cli/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::{copy::CopyCmd, info::InfoCmd};
+use crate::{copy::CopyCmd, info::InfoCmd, security::SecurityCmd};
 use clap::{Parser, Subcommand, ValueEnum};
 use smb::{
     ClientConfig, ConnectionConfig,
@@ -95,4 +95,6 @@ pub enum Commands {
     Copy(CopyCmd),
     /// Retrieves information about a share or a path.
     Info(InfoCmd),
+    /// Configures object security
+    Security(SecurityCmd),
 }

--- a/smb-cli/src/copy.rs
+++ b/smb-cli/src/copy.rs
@@ -103,9 +103,10 @@ impl CopyFile {
             Remote(from_remote) => match to.value {
                 Local(to_local) => block_copy(from_remote, to_local, 16).await?,
                 Remote(to_remote) => {
-                    if to.path.as_remote().unwrap().server == self.path.as_remote().unwrap().server
-                        && to.path.as_remote().unwrap().share
-                            == self.path.as_remote().unwrap().share
+                    if to.path.as_remote().unwrap().server()
+                        == self.path.as_remote().unwrap().server()
+                        && to.path.as_remote().unwrap().share()
+                            == self.path.as_remote().unwrap().share()
                     {
                         // Use server-side copy if both files are on the same server
                         to_remote.srv_copy(&from_remote).await?

--- a/smb-cli/src/lib.rs
+++ b/smb-cli/src/lib.rs
@@ -2,5 +2,6 @@ pub mod cli;
 pub mod copy;
 pub mod info;
 pub mod path;
+pub mod security;
 
 pub use cli::*;

--- a/smb-cli/src/main.rs
+++ b/smb-cli/src/main.rs
@@ -50,6 +50,9 @@ async fn _main() -> Result<(), Box<dyn Error>> {
             log::info!("Getting info for {:?}", cmd.path);
             info::info(cmd, &cli).await?;
         }
+        Commands::Security(cmd) => {
+            security::security(cmd, &cli).await?;
+        }
     }
 
     Ok(())

--- a/smb-cli/src/security.rs
+++ b/smb-cli/src/security.rs
@@ -1,0 +1,263 @@
+use std::str::FromStr;
+
+use super::Cli;
+use clap::{Parser, Subcommand};
+use smb::{
+    packets::{security::*, smb2::AdditionalInfo},
+    *,
+};
+
+#[derive(Parser, Debug)]
+pub struct SecurityCmd {
+    /// The path of the object to work on
+    pub path: UncPath,
+    #[command(subcommand)]
+    pub subcommand: SecuritySubCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SecuritySubCommand {
+    /// Displays the security descriptor of a file or directory.
+    Get(GetSecurityCmd),
+    /// Sets the security descriptor of a file or directory.
+    Set(SetSecurityCmd),
+}
+
+#[derive(Parser, Debug)]
+pub struct GetSecurityCmd {
+    #[arg(long)]
+    pub dacl: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct SetSecurityCmd {
+    /// DACLs to add. This is how you can add allow/deny access for users and groups on the object.
+    /// Format: <allow|deny>:<SID>:<hex-mask>
+    ///
+    /// Example: --add-dacl "allow:S-1-5-21-78297438...:101002ff" - will add the specified SID with the specified mask as an allow ACE.
+    #[arg(long, action = clap::ArgAction::Append)]
+    pub add_dacl: Vec<DaclEntryArg>,
+
+    /// Remove DACL entries for the specified SIDs.
+    ///
+    /// Note: this action is applied before any additions via `--add-dacl`.
+    #[arg(long, action = clap::ArgAction::Append)]
+    pub remove_dacl: Vec<SID>,
+
+    /// Force update ACLs.
+    /// * For DACLs, this will overwrite existing DACL entries with same SID.
+    #[arg(long, short)]
+    pub force: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct DaclEntryArg {
+    pub allow: AceType,
+    pub sid: SID,
+    pub mask: AccessMask,
+}
+
+impl FromStr for DaclEntryArg {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let components = s.split(':').collect::<Vec<_>>();
+        if components.len() != 3 {
+            return Err(
+                "Invalid DACL entry format. Expected format: <allow|deny>:<SID>:<mask>".into(),
+            );
+        }
+
+        let allow = match components[0].to_lowercase().as_str() {
+            "allow" => AceType::AccessAllowed,
+            "deny" => AceType::AccessDenied,
+            _ => return Err("Invalid ACE type. Expected 'allow' or 'deny'".into()),
+        };
+
+        let sid = SID::from_str(components[1]).map_err(|e| format!("Invalid SID: {}", e))?;
+
+        let mask_dword = u32::from_str_radix(components[2].trim_start_matches("0x"), 16)
+            .map_err(|e| format!("Invalid mask: {} - requires a 32-bit hexadecimal value (for example: 101002ff)", e))?;
+        let mask = AccessMask::from_bytes(mask_dword.to_le_bytes());
+
+        Ok(DaclEntryArg { allow, sid, mask })
+    }
+}
+
+#[maybe_async::maybe_async]
+pub async fn security(cmd: &SecurityCmd, cli: &Cli) -> Result<()> {
+    match &cmd.subcommand {
+        SecuritySubCommand::Get(c) => get_security(c, cmd, cli).await,
+        SecuritySubCommand::Set(c) => set_security(c, cmd, cli).await,
+    }
+}
+
+#[maybe_async::maybe_async]
+async fn open_resource(
+    security_cmd: &SecurityCmd,
+    cli: &Cli,
+    access: FileAccessMask,
+) -> Result<Resource> {
+    let client = Client::new(cli.make_smb_client_config());
+
+    if security_cmd.path.share().is_none() || security_cmd.path.share().unwrap().is_empty() {
+        return Err(Error::InvalidArgument(
+            "Specified path must include a share".into(),
+        ));
+    }
+
+    client
+        .share_connect(
+            &security_cmd.path,
+            cli.username.as_ref(),
+            cli.password.clone(),
+        )
+        .await?;
+    let resource = client
+        .create_file(
+            &security_cmd.path,
+            &FileCreateArgs::make_open_existing(access),
+        )
+        .await?;
+    Ok(resource)
+}
+
+#[inline]
+fn resource_handle(resource: &Resource) -> &ResourceHandle {
+    match resource {
+        Resource::File(f) => f.handle(),
+        Resource::Directory(d) => d.handle(),
+        Resource::Pipe(p) => p.handle(),
+    }
+}
+
+#[maybe_async::maybe_async]
+pub async fn get_security(
+    cmd: &GetSecurityCmd,
+    security_cmd: &SecurityCmd,
+    cli: &Cli,
+) -> Result<()> {
+    let access = FileAccessMask::new().with_read_control(true);
+    let resource = open_resource(security_cmd, cli, access).await?;
+    let resource_handle = resource_handle(&resource);
+
+    let additional_info = AdditionalInfo::new().with_dacl_security_information(cmd.dacl);
+    let security_info = resource_handle.query_security_info(additional_info).await?;
+
+    log::info!("Security info for {}:", security_cmd.path);
+    // TODO: pretty print
+    log::info!("{:#?}", security_info);
+
+    resource_handle.close().await?;
+    Ok(())
+}
+
+#[maybe_async::maybe_async]
+pub async fn set_security(
+    cmd: &SetSecurityCmd,
+    security_cmd: &SecurityCmd,
+    cli: &Cli,
+) -> Result<()> {
+    let write_dacl = !cmd.add_dacl.is_empty() || !cmd.remove_dacl.is_empty();
+
+    let access = FileAccessMask::new()
+        .with_read_control(true)
+        .with_write_dacl(write_dacl);
+
+    let resource = open_resource(security_cmd, cli, access).await?;
+    let resource_handle = resource_handle(&resource);
+
+    // Query only the required information ot perform the update
+    let to_set = AdditionalInfo::new().with_dacl_security_information(write_dacl);
+
+    if to_set.into_bytes().iter().all(|f| *f == 0u8) {
+        log::debug!("No security information to set.");
+        return Ok(());
+    }
+
+    let current_security_info = resource_handle.query_security_info(to_set).await?;
+    log::debug!("Current security info: {:#?}", current_security_info);
+
+    let mut new_security_info = current_security_info.clone();
+    if write_dacl {
+        let new_dacl = new_security_info.dacl.as_mut().ok_or_else(|| {
+            log::error!("No DACL present on the object, cannot add entries");
+            Error::InvalidArgument("No DACL present on the object".into())
+        })?;
+
+        // Remove DACLs. Warn if SID not found
+        for sid in &cmd.remove_dacl {
+            let initial_len = new_dacl.ace.len();
+            new_dacl.ace.retain(|ace| match &ace.value {
+                AceValue::AccessAllowed(ace) => &ace.sid != sid,
+                AceValue::AccessDenied(ace) => &ace.sid != sid,
+                _ => true,
+            });
+            if new_dacl.ace.len() == initial_len {
+                log::warn!("No ACE found for SID {}, cannot remove", sid);
+            }
+            log::debug!(
+                "Removed {} DACL entries for SID {}",
+                initial_len - new_dacl.ace.len(),
+                sid
+            );
+        }
+
+        // Add DACLs
+        for entry in &cmd.add_dacl {
+            // Make value
+            let access_ace_value_inner = AccessAce {
+                access_mask: entry.mask,
+                sid: entry.sid.clone(),
+            };
+            let value = match entry.allow {
+                AceType::AccessAllowed => AceValue::AccessAllowed(access_ace_value_inner),
+                AceType::AccessDenied => AceValue::AccessDenied(access_ace_value_inner),
+                _ => unimplemented!("Unsupported ACE type"),
+            };
+
+            // Locate existing entry with same SID
+            let existing_ace_to_update = new_dacl.ace.iter_mut().find(|ace| match &ace.value {
+                AceValue::AccessAllowed(ace) => ace.sid == entry.sid,
+                AceValue::AccessDenied(ace) => ace.sid == entry.sid,
+                _ => false,
+            });
+            if let Some(ace) = existing_ace_to_update {
+                if !cmd.force {
+                    log::warn!(
+                        "ACE for SID {} with mask {:x?} already exists, skipping (use --force to overwrite)",
+                        entry.sid,
+                        entry.mask
+                    );
+                    continue;
+                }
+                log::debug!(
+                    "ACE for SID {} already exists, overwriting (mask {:x?})",
+                    entry.sid,
+                    entry.mask
+                );
+                // Update
+                ace.value = value;
+                new_dacl.order_aces();
+            } else {
+                // Insert
+                log::debug!(
+                    "Adding ACE for SID {} with mask {:x?}",
+                    entry.sid,
+                    entry.mask
+                );
+                new_dacl.insert_ace(ACE {
+                    ace_flags: AceFlags::new(),
+                    value,
+                })
+            }
+        }
+    }
+
+    log::debug!("New security info to set: {:#?}", new_security_info);
+    resource_handle
+        .set_security_info(new_security_info, to_set)
+        .await?;
+    resource_handle.close().await?;
+    Ok(())
+}

--- a/smb/Cargo.toml
+++ b/smb/Cargo.toml
@@ -33,7 +33,7 @@ url = "2.5.0"
 byteorder = { version = "1.5.0", optional = true }
 
 # APIs
-sspi = { version = "0.16.1", features = ["ring"], no-default-features = true }
+sspi = { version = "0.16.1", features = ["ring"], default-features = false }
 
 # Crypto
 hmac = "0.12.1"

--- a/smb/src/docs/index.md
+++ b/smb/src/docs/index.md
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     client.share_connect(&target_path, "username", "password".to_string()).await?;
     
     // And open a file on the server
-    let file_to_open = target_path.with_path("file.txt".to_string());
+    let file_to_open = target_path.with_path("file.txt");
     let file_open_args = FileCreateArgs::make_open_existing(FileAccessMask::new().with_generic_read(true));
     let file = client.create_file(&file_to_open, &file_open_args).await?;
     // now, you can do a bunch of operations against `file`, and close it at the end.
@@ -41,7 +41,7 @@ But wait... How do we know it's actually a file? Well, we don't. The [`Client::c
 # #[cfg(feature = "async")]
 # async fn main() -> Result<()> {
 # let client = Client::default();
-# let mut file = client.create_file(&UncPath::new(String::new()), &FileCreateArgs::default()).await?;
+# let mut file = client.create_file(&UncPath::new("")?, &FileCreateArgs::default()).await?;
 match &file {
     Resource::File(file) => {
         // We have a file
@@ -66,7 +66,7 @@ Cool! Let's assume we got ourselves a file. Then, we can do the obvious operatio
 # #[tokio::main]
 # async fn main() -> Result<()> {
 # let client = Client::default();
-# let mut file = client.create_file(&UncPath::new(String::new()), &FileCreateArgs::default()).await?;
+# let mut file = client.create_file(&UncPath::new("")?, &FileCreateArgs::default()).await?;
 let file: File = file.unwrap_file();
 
 let mut data: [u8; 1024] = [0; 1024];
@@ -83,7 +83,7 @@ At the end, close the file.
 # #[tokio::main]
 # async fn main() -> Result<()> {
 # let client = Client::default();
-# let mut file = client.create_file(&UncPath::new(String::new()), &FileCreateArgs::default()).await?;
+# let mut file = client.create_file(&UncPath::new("")?, &FileCreateArgs::default()).await?;
 # let file: File = file.unwrap_file();
 file.close().await?;
 # Ok(())}

--- a/smb/src/docs/threading_models.md
+++ b/smb/src/docs/threading_models.md
@@ -39,7 +39,7 @@ async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     client.share_connect(&target_path, "username", "password".to_string()).await?;
     
     // And open a file on the server
-    let file_to_open = target_path.with_path("file.txt".to_string());
+    let file_to_open = target_path.with_path("file.txt");
     let read_access= FileAccessMask::new().with_generic_read(true);
     let file_open_args = FileCreateArgs::make_open_existing(read_access);
     let file = client.create_file(&file_to_open, &file_open_args).await?;

--- a/smb/src/packets/security/acl.rs
+++ b/smb/src/packets/security/acl.rs
@@ -7,7 +7,7 @@ use crate::packets::binrw_util::prelude::*;
 use super::ACE;
 
 #[binrw::binrw]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ACL {
     pub acl_revision: AclRevision,
     #[bw(calc = 0)]
@@ -20,17 +20,132 @@ pub struct ACL {
     #[bw(calc = 0)]
     #[br(assert(sbz2 == 0))]
     sbz2: u16,
+
     #[br(count = ace_count)]
-    #[bw(write_with = PosMarker::write_size, args(&_acl_size))]
+    #[bw(write_with = PosMarker::write_size_plus, args(&_acl_size, Self::HEADER_SIZE))]
     pub ace: Vec<ACE>,
 }
 
+impl ACL {
+    const HEADER_SIZE: u64 = 8;
+
+    /// Orders the ACEs in the ACL according to the standard order.
+    ///
+    /// Note that since we do not have sufficient information about the inheritance,
+    /// we only apply order which is independent of inheritance.
+    ///
+    /// The following steps describe the preferred order:
+    /// 1. ✅ All explicit ACEs are placed in a group before any inherited ACEs.
+    /// 2. ✅ Within the group of explicit ACEs, access-denied ACEs are placed before access-allowed ACEs.
+    /// 3. ❌ Inherited ACEs are placed in the order in which they are inherited. ACEs inherited from the child object's parent come first, then ACEs inherited from the grandparent, and so on up the tree of objects.
+    /// 4. ❌ For each level of inherited ACEs, access-denied ACEs are placed before access-allowed ACEs.
+    ///
+    /// See more information on [Order of ACEs in a DACL - MSDN](<https://learn.microsoft.com/en-us/windows/win32/secauthz/order-of-aces-in-a-dacl>)
+    pub fn order_aces(&mut self) {
+        self.ace.sort_by(Self::sort_aces_by);
+    }
+
+    /// Whether ACE ordering rules apply to this ACL.
+    ///
+    /// See [`order_aces`][ACL::order_aces] for the ordering rules.
+    pub fn is_ace_sorted(&self) -> bool {
+        self.ace
+            .is_sorted_by(|a, b| Self::sort_aces_by(a, b).is_le())
+    }
+
+    /// Sorting function for ACEs.
+    ///
+    /// See [`order_aces`][ACL::order_aces] for the ordering rules.
+    fn sort_aces_by(a: &ACE, b: &ACE) -> std::cmp::Ordering {
+        let a_inherited = a.ace_flags.inherited();
+        let b_inherited = b.ace_flags.inherited();
+        if a_inherited != b_inherited {
+            return a_inherited.cmp(&b_inherited); // (1)
+        }
+        if a_inherited {
+            return std::cmp::Ordering::Equal; // keep original order for inherited ACEs (3)
+        }
+        let a_denied = a.value.is_access_allowed();
+        let b_denied = b.value.is_access_allowed();
+        a_denied.cmp(&b_denied) // (2) on explicit ACEs, access-denied first <=> access-allowed last
+        // Note: the sort is stable, so we keep the original order for inherited ACEs
+    }
+
+    /// Insert an ACE into the ACL, maintaining the correct order.
+    /// See [`order_aces`][ACL::order_aces] for the ordering rules.
+    pub fn insert_ace(&mut self, ace: ACE) {
+        self.ace.push(ace);
+        self.order_aces();
+    }
+}
+
 #[binrw::binrw]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[brw(repr(u8))]
 pub enum AclRevision {
     /// Windows NT 4.0
     Nt4 = 2,
     /// Active directory
     DS = 4,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::packets::security::{AccessAce, AccessMask, AceFlags, AceValue, SID};
+    use std::str::FromStr;
+
+    use super::*;
+    #[test]
+    fn test_sort_acls() {
+        let fake_access_ace = AccessAce {
+            access_mask: AccessMask::new(),
+            sid: SID::from_str(SID::S_EVERYONE).unwrap(),
+        };
+        let explicit_deny_first = ACE {
+            ace_flags: AceFlags::new().with_inherited(false),
+            value: AceValue::AccessDenied(fake_access_ace.clone()),
+        };
+        let explicit_allow_second = ACE {
+            ace_flags: AceFlags::new().with_inherited(false),
+            value: AceValue::AccessAllowed(fake_access_ace.clone()),
+        };
+        // Let's make sure inherited remain untouched (in allow/deny difference)
+        let inherited_last_1 = ACE {
+            ace_flags: AceFlags::new().with_inherited(true),
+            value: AceValue::AccessAllowed(fake_access_ace.clone()),
+        };
+        let inherited_last_2 = ACE {
+            ace_flags: AceFlags::new().with_inherited(true),
+            value: AceValue::AccessDenied(fake_access_ace.clone()),
+        };
+        let dacl = ACL {
+            acl_revision: AclRevision::Nt4,
+            ace: vec![
+                inherited_last_1.clone(),      // should go third - before inherited_last_2
+                explicit_allow_second.clone(), // should go second
+                explicit_deny_first.clone(),   // should go first
+                inherited_last_2.clone(), // should stay in place - inherited_last_1 before inherited_last_2
+            ],
+        };
+
+        assert!(!dacl.is_ace_sorted());
+
+        let mut new_dacl = dacl.clone();
+        new_dacl.order_aces();
+
+        assert!(new_dacl.is_ace_sorted());
+
+        assert_eq!(
+            new_dacl,
+            ACL {
+                acl_revision: AclRevision::Nt4,
+                ace: vec![
+                    explicit_deny_first,
+                    explicit_allow_second,
+                    inherited_last_1,
+                    inherited_last_2,
+                ]
+            }
+        );
+    }
 }

--- a/smb/src/packets/security/tests.rs
+++ b/smb/src/packets/security/tests.rs
@@ -1,119 +1,133 @@
 use super::*;
-use std::str::FromStr;
+use std::{io::Cursor, str::FromStr};
 
 use binrw::prelude::*;
 
-#[test]
-pub fn test_owner_group_parse() {
-    let buff = &[
-        0x1, 0x0, 0x0, 0x80, 0x14, 0x0, 0x0, 0x0, 0x30, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-        0x0, 0x0, 0x0, 0x1, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5, 0x15, 0x0, 0x0, 0x0, 0x17, 0x3d,
-        0xa7, 0x2e, 0x95, 0x56, 0x53, 0xf9, 0x15, 0xdf, 0xf2, 0x80, 0xe9, 0x3, 0x0, 0x0, 0x1, 0x5,
-        0x0, 0x0, 0x0, 0x0, 0x0, 0x5, 0x15, 0x0, 0x0, 0x0, 0x17, 0x3d, 0xa7, 0x2e, 0x95, 0x56,
-        0x53, 0xf9, 0x15, 0xdf, 0xf2, 0x80, 0xe9, 0x3, 0x0, 0x0,
-    ];
-    let sd = SecurityDescriptor::read(&mut std::io::Cursor::new(buff)).unwrap();
-    assert_eq!(
-        sd,
-        SecurityDescriptor {
-            sbz1: 0,
-            control: SecurityDescriptorControl::new().with_self_relative(true),
-            owner_sid: Some(
-                SID::from_str("S-1-5-21-782712087-4182988437-2163400469-1001").unwrap()
-            ),
-            group_sid: Some(
-                SID::from_str("S-1-5-21-782712087-4182988437-2163400469-1001").unwrap()
-            ),
-            sacl: None,
-            dacl: None
-        }
-    )
+const OWNER_GROUP_SD: &[u8] = &[
+    0x1, 0x0, 0x0, 0x80, 0x14, 0x0, 0x0, 0x0, 0x30, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+    0x0, 0x0, 0x1, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5, 0x15, 0x0, 0x0, 0x0, 0x17, 0x3d, 0xa7, 0x2e,
+    0x95, 0x56, 0x53, 0xf9, 0x15, 0xdf, 0xf2, 0x80, 0xe9, 0x3, 0x0, 0x0, 0x1, 0x5, 0x0, 0x0, 0x0,
+    0x0, 0x0, 0x5, 0x15, 0x0, 0x0, 0x0, 0x17, 0x3d, 0xa7, 0x2e, 0x95, 0x56, 0x53, 0xf9, 0x15, 0xdf,
+    0xf2, 0x80, 0xe9, 0x3, 0x0, 0x0,
+];
+
+fn owner_group_sd() -> SecurityDescriptor {
+    SecurityDescriptor {
+        sbz1: 0,
+        control: SecurityDescriptorControl::new().with_self_relative(true),
+        owner_sid: Some(SID::from_str("S-1-5-21-782712087-4182988437-2163400469-1001").unwrap()),
+        group_sid: Some(SID::from_str("S-1-5-21-782712087-4182988437-2163400469-1001").unwrap()),
+        sacl: None,
+        dacl: None,
+    }
 }
 
 #[test]
-pub fn test_dacl_only_parse() {
-    let buff = &[
-        0x1, 0x0, 0x4, 0x84, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x14, 0x0,
-        0x0, 0x0, 0x2, 0x0, 0x90, 0x0, 0x5, 0x0, 0x0, 0x0, 0x0, 0x13, 0x24, 0x0, 0xff, 0x1, 0x1f,
-        0x0, 0x1, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5, 0x15, 0x0, 0x0, 0x0, 0x17, 0x3d, 0xa7, 0x2e,
-        0x95, 0x56, 0x53, 0xf9, 0x15, 0xdf, 0xf2, 0x80, 0xe9, 0x3, 0x0, 0x0, 0x0, 0x13, 0x18, 0x0,
-        0xff, 0x1, 0x1f, 0x0, 0x1, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5, 0x20, 0x0, 0x0, 0x0, 0x20,
-        0x2, 0x0, 0x0, 0x0, 0x13, 0x14, 0x0, 0xff, 0x1, 0x1f, 0x0, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0,
-        0x0, 0x5, 0x12, 0x0, 0x0, 0x0, 0x0, 0x13, 0x14, 0x0, 0xa9, 0x0, 0x12, 0x0, 0x1, 0x1, 0x0,
-        0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x13, 0x24, 0x0, 0xff, 0x1, 0x1f, 0x0,
-        0x1, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5, 0x15, 0x0, 0x0, 0x0, 0x17, 0x3d, 0xa7, 0x2e, 0x95,
-        0x56, 0x53, 0xf9, 0x15, 0xdf, 0xf2, 0x80, 0xea, 0x3, 0x0, 0x0,
-    ];
-    let sd = SecurityDescriptor::read(&mut std::io::Cursor::new(buff)).unwrap();
-    assert_eq!(
-        sd,
-        SecurityDescriptor {
-            sbz1: 0,
-            control: SecurityDescriptorControl::new()
-                .with_self_relative(true)
-                .with_dacl_auto_inherited(true)
-                .with_dacl_present(true),
-            owner_sid: None,
-            group_sid: None,
-            sacl: None,
-            dacl: ACL {
-                acl_revision: AclRevision::Nt4,
-                ace: vec![
-                    ACE {
-                        ace_flags: AceFlags::new()
-                            .with_inherited(true)
-                            .with_container_inherit(true)
-                            .with_object_inherit(true),
-                        value: AceValue::AccessAllowed(AccessAce {
-                            access_mask: AccessMask::from_bytes(0x1f01ffu32.to_le_bytes()),
-                            sid: SID::from_str("S-1-5-21-782712087-4182988437-2163400469-1001")
-                                .unwrap()
-                        })
-                    },
-                    ACE {
-                        ace_flags: AceFlags::new()
-                            .with_inherited(true)
-                            .with_container_inherit(true)
-                            .with_object_inherit(true),
-                        value: AceValue::AccessAllowed(AccessAce {
-                            access_mask: AccessMask::from_bytes(0x1f01ffu32.to_le_bytes()),
-                            sid: SID::from_str(SID::S_ADMINISTRATORS).unwrap()
-                        })
-                    },
-                    ACE {
-                        ace_flags: AceFlags::new()
-                            .with_inherited(true)
-                            .with_container_inherit(true)
-                            .with_object_inherit(true),
-                        value: AceValue::AccessAllowed(AccessAce {
-                            access_mask: AccessMask::from_bytes(0x1f01ffu32.to_le_bytes()),
-                            sid: SID::from_str(SID::S_LOCAL_SYSTEM).unwrap()
-                        })
-                    },
-                    ACE {
-                        ace_flags: AceFlags::new()
-                            .with_inherited(true)
-                            .with_container_inherit(true)
-                            .with_object_inherit(true),
-                        value: AceValue::AccessAllowed(AccessAce {
-                            access_mask: AccessMask::from_bytes(0x1200a9u32.to_le_bytes()),
-                            sid: SID::from_str(SID::S_EVERYONE).unwrap()
-                        })
-                    },
-                    ACE {
-                        ace_flags: AceFlags::new()
-                            .with_inherited(true)
-                            .with_container_inherit(true)
-                            .with_object_inherit(true),
-                        value: AceValue::AccessAllowed(AccessAce {
-                            access_mask: AccessMask::from_bytes(0x1f01ffu32.to_le_bytes()),
-                            sid: SID::from_str("S-1-5-21-782712087-4182988437-2163400469-1002")
-                                .unwrap()
-                        })
-                    },
-                ]
-            }
-            .into()
+fn test_owner_group_parse() {
+    let sd = SecurityDescriptor::read(&mut std::io::Cursor::new(OWNER_GROUP_SD)).unwrap();
+    assert_eq!(sd, owner_group_sd())
+}
+
+#[test]
+fn test_owner_group_write() {
+    let mut written = Cursor::new(vec![]);
+    owner_group_sd().write(&mut written).unwrap();
+    assert_eq!(written.into_inner(), OWNER_GROUP_SD);
+}
+
+fn dacl_only_sd() -> SecurityDescriptor {
+    SecurityDescriptor {
+        sbz1: 0,
+        control: SecurityDescriptorControl::new()
+            .with_self_relative(true)
+            .with_dacl_auto_inherited(true)
+            .with_dacl_present(true),
+        owner_sid: None,
+        group_sid: None,
+        sacl: None,
+        dacl: ACL {
+            acl_revision: AclRevision::Nt4,
+            ace: vec![
+                ACE {
+                    ace_flags: AceFlags::new()
+                        .with_inherited(true)
+                        .with_container_inherit(true)
+                        .with_object_inherit(true),
+                    value: AceValue::AccessAllowed(AccessAce {
+                        access_mask: AccessMask::from_bytes(0x1f01ffu32.to_le_bytes()),
+                        sid: SID::from_str("S-1-5-21-782712087-4182988437-2163400469-1001")
+                            .unwrap(),
+                    }),
+                },
+                ACE {
+                    ace_flags: AceFlags::new()
+                        .with_inherited(true)
+                        .with_container_inherit(true)
+                        .with_object_inherit(true),
+                    value: AceValue::AccessAllowed(AccessAce {
+                        access_mask: AccessMask::from_bytes(0x1f01ffu32.to_le_bytes()),
+                        sid: SID::from_str(SID::S_ADMINISTRATORS).unwrap(),
+                    }),
+                },
+                ACE {
+                    ace_flags: AceFlags::new()
+                        .with_inherited(true)
+                        .with_container_inherit(true)
+                        .with_object_inherit(true),
+                    value: AceValue::AccessAllowed(AccessAce {
+                        access_mask: AccessMask::from_bytes(0x1f01ffu32.to_le_bytes()),
+                        sid: SID::from_str(SID::S_LOCAL_SYSTEM).unwrap(),
+                    }),
+                },
+                ACE {
+                    ace_flags: AceFlags::new()
+                        .with_inherited(true)
+                        .with_container_inherit(true)
+                        .with_object_inherit(true),
+                    value: AceValue::AccessAllowed(AccessAce {
+                        access_mask: AccessMask::from_bytes(0x1200a9u32.to_le_bytes()),
+                        sid: SID::from_str(SID::S_EVERYONE).unwrap(),
+                    }),
+                },
+                ACE {
+                    ace_flags: AceFlags::new()
+                        .with_inherited(true)
+                        .with_container_inherit(true)
+                        .with_object_inherit(true),
+                    value: AceValue::AccessAllowed(AccessAce {
+                        access_mask: AccessMask::from_bytes(0x1f01ffu32.to_le_bytes()),
+                        sid: SID::from_str("S-1-5-21-782712087-4182988437-2163400469-1002")
+                            .unwrap(),
+                    }),
+                },
+            ],
         }
-    )
+        .into(),
+    }
+}
+
+const DACL_ONLY_DATA: &[u8] = &[
+    0x1, 0x0, 0x4, 0x84, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x14, 0x0,
+    0x0, 0x0, 0x2, 0x0, 0x90, 0x0, 0x5, 0x0, 0x0, 0x0, 0x0, 0x13, 0x24, 0x0, 0xff, 0x1, 0x1f, 0x0,
+    0x1, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5, 0x15, 0x0, 0x0, 0x0, 0x17, 0x3d, 0xa7, 0x2e, 0x95,
+    0x56, 0x53, 0xf9, 0x15, 0xdf, 0xf2, 0x80, 0xe9, 0x3, 0x0, 0x0, 0x0, 0x13, 0x18, 0x0, 0xff, 0x1,
+    0x1f, 0x0, 0x1, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5, 0x20, 0x0, 0x0, 0x0, 0x20, 0x2, 0x0, 0x0,
+    0x0, 0x13, 0x14, 0x0, 0xff, 0x1, 0x1f, 0x0, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5, 0x12, 0x0,
+    0x0, 0x0, 0x0, 0x13, 0x14, 0x0, 0xa9, 0x0, 0x12, 0x0, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x13, 0x24, 0x0, 0xff, 0x1, 0x1f, 0x0, 0x1, 0x5, 0x0, 0x0, 0x0, 0x0,
+    0x0, 0x5, 0x15, 0x0, 0x0, 0x0, 0x17, 0x3d, 0xa7, 0x2e, 0x95, 0x56, 0x53, 0xf9, 0x15, 0xdf,
+    0xf2, 0x80, 0xea, 0x3, 0x0, 0x0,
+];
+
+#[test]
+fn test_dacl_only_parse() {
+    let sd = SecurityDescriptor::read(&mut std::io::Cursor::new(DACL_ONLY_DATA)).unwrap();
+    assert_eq!(sd, dacl_only_sd())
+}
+
+#[test]
+fn test_dacl_only_write() {
+    let mut written = Cursor::new(vec![]);
+    dacl_only_sd().write(&mut written).unwrap();
+    assert_eq!(written.into_inner(), DACL_ONLY_DATA);
 }

--- a/smb/src/resource.rs
+++ b/smb/src/resource.rs
@@ -285,6 +285,12 @@ impl ResourceHandle {
         self.share_type
     }
 
+    /// Returns the handle of the resource.
+    // This is implemented to be "inhrited" by Deref impl of resources impls, to avoid boilerplate code.
+    pub fn handle(&self) -> &ResourceHandle {
+        self
+    }
+
     /// (Internal)
     ///
     /// Returns the file ID of the resource, ensuring the resource is still open.

--- a/smb/src/resource/pipe.rs
+++ b/smb/src/resource/pipe.rs
@@ -18,10 +18,6 @@ impl Pipe {
         Pipe { handle }
     }
 
-    pub fn handle(&self) -> &ResourceHandle {
-        &self.handle
-    }
-
     #[maybe_async]
     pub async fn bind<I>(self) -> crate::Result<I>
     where

--- a/smb/tests/basic.rs
+++ b/smb/tests/basic.rs
@@ -22,7 +22,7 @@ async fn do_test_basic_integration(
     // Create a file
     let file = client
         .create_file(
-            &share_path.with_path("basic.txt".to_string()),
+            &share_path.with_path("basic.txt"),
             &FileCreateArgs::make_create_new(Default::default(), Default::default()),
         )
         .await?

--- a/smb/tests/closes.rs
+++ b/smb/tests/closes.rs
@@ -16,7 +16,7 @@ async fn _close_tests_helper()
 -> smb::Result<(Client, Arc<Connection>, Arc<Session>, Arc<Tree>, File)> {
     let (client, unc) =
         make_server_connection(TestConstants::DEFAULT_SHARE, Default::default()).await?;
-    let file_path = unc.with_path("file.txt".to_string());
+    let file_path = unc.with_path("file.txt");
     let file = client
         .create_file(
             &file_path,
@@ -25,7 +25,7 @@ async fn _close_tests_helper()
         .await?;
     let file = file.unwrap_file();
     file.set_info(FileDispositionInformation::default()).await?;
-    let connection = client.get_connection(&file_path.server).await?;
+    let connection = client.get_connection(file_path.server()).await?;
     let session = client.get_session(&file_path).await?;
     let tree = client.get_tree(&file_path).await?;
 

--- a/smb/tests/common.rs
+++ b/smb/tests/common.rs
@@ -44,11 +44,7 @@ pub async fn make_server_connection(
     });
     log::info!("Connecting to {server}");
 
-    let unc_path = UncPath {
-        server: server.clone(),
-        share: Some(share.to_string()),
-        path: None,
-    };
+    let unc_path = UncPath::new(&server)?.with_share(share)?;
     // Connect & Authenticate
     smb.share_connect(&unc_path, user.as_str(), password.clone())
         .await?;

--- a/smb/tests/dialects.rs
+++ b/smb/tests/dialects.rs
@@ -63,7 +63,7 @@ async fn test_smb_integration_dialect_encrpytion_mode(
     const TEST_FILE: &str = "test.txt";
     const TEST_DATA: &[u8] = b"Hello, World!";
 
-    let test_file_path = share_path.clone().with_path(TEST_FILE.to_string());
+    let test_file_path = share_path.clone().with_path(TEST_FILE);
 
     // Hello, World! > test.txt
     let security = {

--- a/smb/tests/long_dir.rs
+++ b/smb/tests/long_dir.rs
@@ -41,7 +41,7 @@ async fn test_smb_iterating_long_directory() -> Result<(), Box<dyn std::error::E
     .await?;
 
     let client = Arc::new(Mutex::new(client));
-    let long_dir_path = share_path.clone().with_path(LONG_DIR.to_string());
+    let long_dir_path = share_path.clone().with_path(LONG_DIR);
     // Mkdir
     client
         .lock()
@@ -64,7 +64,7 @@ async fn test_smb_iterating_long_directory() -> Result<(), Box<dyn std::error::E
             .await
             .unwrap()
             .create_file(
-                &share_path.clone().with_path(file_name),
+                &share_path.clone().with_path(&file_name),
                 &FileCreateArgs::make_create_new(Default::default(), Default::default()),
             )
             .await?
@@ -107,7 +107,7 @@ async fn test_smb_iterating_long_directory() -> Result<(), Box<dyn std::error::E
             assert!(file_number < NUM_FILES);
 
             // .. And delete the file!
-            let full_file_path = share_path.with_path(format!("{}\\{}", LONG_DIR, file_name));
+            let full_file_path = share_path.with_path(&format!("{}\\{}", LONG_DIR, file_name));
             let file = client
                 .lock()
                 .await

--- a/smb/tests/notify.rs
+++ b/smb/tests/notify.rs
@@ -32,9 +32,7 @@ async fn test_smb_notify() -> Result<(), Box<dyn std::error::Error>> {
     // Create the file
     client
         .create_file(
-            &share_path
-                .clone()
-                .with_path(NEW_FILE_NAME_UNDER_WORKDIR.to_string()),
+            &share_path.clone().with_path(NEW_FILE_NAME_UNDER_WORKDIR),
             &FileCreateArgs::make_create_new(Default::default(), Default::default()),
         )
         .await?
@@ -114,7 +112,7 @@ async fn delete_file_from_another_connection(
 
     let file = client
         .create_file(
-            &share_path.with_path(NEW_FILE_NAME_UNDER_WORKDIR.to_string()),
+            &share_path.with_path(NEW_FILE_NAME_UNDER_WORKDIR),
             &FileCreateArgs::make_open_existing(
                 FileAccessMask::new()
                     .with_delete(true)


### PR DESCRIPTION
- Add security get & set CLI for example
- Add ACL sort function
- Fix major SD write bug (no offset writeback)
- Fix ACL+ACE write bug (bad size calc)
- Add SD write tests
- UncPath: accept &str instead of owned String
- UncPath: normalize dir sep, hide internals
- Fix sspi no-default-features invalid syntax