### PR TITLE
Use `kbkdf` from RustCrypto instead of deprecated `rust-kbkdf`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,6 +1268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kbkdf"
+version = "0.1.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97e1f9b50adafd503518a832b24241dca1d319bfc27e9e708bcf220b0b25419"
+dependencies = [
+ "digest 0.11.0-rc.3",
+]
+
+[[package]]
 name = "keccak"
 version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,17 +2082,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-kbkdf"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb211667cbc3291d401a54f7499904001c2cfc3347844120443bffca6fa0590"
-dependencies = [
- "generic-array",
- "typenum",
- "zeroize",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +2455,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hmac",
+ "kbkdf",
  "log",
  "lz4_flex",
  "maybe-async",
@@ -2464,7 +2463,6 @@ dependencies = [
  "pastey",
  "rand 0.8.5",
  "reqwest",
- "rust-kbkdf",
  "serial_test",
  "sha2",
  "smb-dtyp",

--- a/crates/smb/Cargo.toml
+++ b/crates/smb/Cargo.toml
@@ -48,7 +48,7 @@ reqwest = { workspace = true, optional = true }
 # Crypto; RustCrypto provides support for RC versions only.
 hmac = "0.13.0-rc.2"
 sha2 = "0.11.0-rc.2"
-rust-kbkdf = { version = "1.1.1" }
+kbkdf = { version = "0.1.0-pre.0" }
 crypto-common = { version = "0.2.0-rc.4" }
 aes = "0.9.0-rc.1"
 aes-gcm = { version = "0.11.0-rc.1", optional = true }

--- a/crates/smb/src/session/state.rs
+++ b/crates/smb/src/session/state.rs
@@ -471,7 +471,7 @@ impl<'a> KeyDeriver<'a> {
 
     #[inline]
     pub fn derive(&self, label: &[u8], context: &'a [u8]) -> Result<DerivedKey, CryptoError> {
-        kbkdf_hmacsha256::<16>(self.session_key, label, context)
+        kbkdf_hmacsha256(self.session_key, label, context)
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated cryptographic dependency to a newer kbkdf implementation.
  * Simplified internal key-derivation logic to use the new counter-based derivation.
  * No changes to public-facing behavior or APIs for consumers of the crate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->