### PR TITLE
fix: allow async SMB read responses

### DIFF
--- a/crates/smb/src/resource/file.rs
+++ b/crates/smb/src/resource/file.rs
@@ -109,7 +109,7 @@ impl File {
 
         let response = self
             .handle
-            .sendo_recvo(request, ReceiveOptions::new())
+            .sendo_recvo(request, ReceiveOptions::new().with_allow_async(true))
             .await
             .map_err(|e| std::io::Error::other(e.to_string()))?;
         let content = response


### PR DESCRIPTION
Closes #165

## Summary
- allow `File::read_block` to accept async SMB2 responses
- reuse the existing pending-response handling instead of rejecting the read immediately

## Why
This fixes a real downstream problem in OpenDAL's new SMB backend draft PR: [apache/opendal#7374](https://github.com/apache/opendal/pull/7374).

That OpenDAL branch is intentionally **not** carrying a local `smb-rs` fork. With crates.io `smb = 0.11.1`, a real Samba behavior run still hits read-path failures like:

```text
IO Error: Invalid argument: Async command is not allowed in this context.
```

OpenDAL only passes today because its retry layer reconnects and retries those reads. In other words, the downstream behavior suite is green, but only because retries are masking this `smb-rs` bug.

This change makes `read_block` consistent with the existing write path, which already calls `with_allow_async(true)`.

## Public downstream reproduction
The downstream reproduction is public now:

- OpenDAL draft PR: [apache/opendal#7374](https://github.com/apache/opendal/pull/7374)
- OpenDAL commit: `41faefd11f0f76253136e6aaa610bf360342d0a2`

To reproduce the bug without this fix:

```bash
git clone https://github.com/apache/opendal.git
cd opendal
git fetch https://github.com/suyanhanx/opendal.git feat/smb-service
git checkout 41faefd11f0f76253136e6aaa610bf360342d0a2
cd core
RUST_LOG=debug \
OPENDAL_TEST=smb \
OPENDAL_SMB_ENDPOINT=127.0.0.1:1445 \
OPENDAL_SMB_SHARE=MyShare \
OPENDAL_SMB_ROOT=/ \
OPENDAL_SMB_USER=alice \
OPENDAL_SMB_PASSWORD=alipass \
cargo test -p opendal --features tests,services-smb behavior -- --nocapture
```

Observed downstream behavior with crates.io `smb = 0.11.1`:

- final result is still `92 passed; 0 failed`
- debug logs show many async pending responses
- some large reads also log `Async command is not allowed in this context`
- OpenDAL retry logs then show the same read being retried successfully

Representative downstream log lines:

```text
IO Error: Invalid argument: Async command is not allowed in this context.
will retry after 1s because: Unexpected (temporary) at read ... Async command is not allowed in this context.
```

## Validation
- `cargo check -p smb`

To validate this change against the public downstream repro above, temporarily point the OpenDAL checkout to this PR branch and rerun the same behavior command. For example:

```toml
[patch.crates-io]
smb = { git = "https://github.com/suyanhanx/smb-rs", branch = "fix/allow-async-read-response" }
```

Expected result with this PR applied:

- the same OpenDAL behavior command still finishes `92 passed; 0 failed`
- async pending responses are still observed in debug logs
- the previous `Async command is not allowed in this context` read failures disappear
- OpenDAL no longer needs retry to recover those reads

