### PR TITLE
fix: remove MxAc-based read_block pre-check

### DIFF
--- a/crates/smb/src/resource/file.rs
+++ b/crates/smb/src/resource/file.rs
@@ -65,13 +65,6 @@ impl File {
             return Ok(0);
         }
 
-        if !self.access.file_read_data() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::PermissionDenied,
-                "No read permission",
-            ));
-        }
-
         // EOF
         if pos >= self.end_of_file {
             return Ok(0);


### PR DESCRIPTION
Fixes #170.

The surgical Option A variant we offered in the issue: delete the
client-side MxAc gate at the start of `File::read_block`. Six lines
removed from `crates/smb/src/resource/file.rs:68-73`.

## What's changing

`read_block` previously returned `PermissionDenied("No read permission")`
without sending a `ReadRequest` PDU when `self.access.file_read_data()`
was false. `self.access` is populated from the MxAc create-context
response, which reflects DACL-derived access only — it does not factor
in privilege-based bypasses (`SeBackupPrivilege` on Windows,
`ISI_PRIV_IFS_BACKUP` on OneFS, equivalent on Samba). On a backup-intent
open against a file the user lacks DACL read on, MxAc reports zero, but
the server will honor the wire Read because privilege bypasses DACL at
I/O dispatch time. The pre-check was producing a false negative.

After this change, the server remains the access authority. On a
genuine denial the existing wire-error pipeline at `file.rs:110-119`
returns the same `std::io::ErrorKind::PermissionDenied` error type.
The only observable change is one extra round trip on truly-denied
reads.

## Why surgical, not wholesale

The same pre-check pattern exists at five other sites and the same
analysis suggests they share the same false-negative bug on
backup-intent opens:
- `file.rs:169` (`write_block_zc`)
- `file.rs:241` and `file.rs:246` (`srv_copy` dest and src)
- `directory.rs:51` and `directory.rs:455` (directory queries)

We only empirically verified `read_block` in our use case (NAS
migration, where backup-intent reads are the default). The other five
paths look theoretically affected but we didn't exercise them.
Deferring to follow-up issues or your call rather than ship a fix we
didn't test.

## Verification

- Builds clean against current `main` (v0.11.2).
- `cargo test --lib` passes (no existing tests assert on the pre-check
  behavior — confirmed by the test-finding survey in #170).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined file read behavior by removing redundant local access checks and deferring validation to the protocol request/response flow, simplifying read logic and ensuring access outcomes are determined by the server response.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/afiffon/smb-rs/pull/171)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->